### PR TITLE
add solarized termcolor themes

### DIFF
--- a/rc/themes/solarized-dark-termcolors.kak
+++ b/rc/themes/solarized-dark-termcolors.kak
@@ -1,0 +1,24 @@
+# Powerline colorscheme for solarized-dark-termcolors Kakoune theme
+
+set-option -add global powerline_themes "solarized-dark-termcolors"
+
+define-command -hidden powerline-theme-solarized-dark-termcolors %{
+    set-option global powerline_base_bg        black
+    set-option global powerline_git_fg         cyan
+    set-option global powerline_git_bg         black
+    set-option global powerline_bufname_fg     black
+    set-option global powerline_bufname_bg     bright-cyan
+    set-option global powerline_line_column_fg black
+    set-option global powerline_line_column_bg bright-yellow
+    set-option global powerline_mode_info_fg   bright-cyan
+    set-option global powerline_mode_info_bg   black
+    set-option global powerline_filetype_fg    black
+    set-option global powerline_filetype_bg    bright-cyan
+    set-option global powerline_client_fg      black
+    set-option global powerline_client_bg      bright-blue
+    set-option global powerline_session_fg     black
+    set-option global powerline_session_bg     bright-yellow
+    set-option global powerline_position_fg    bright-red
+    set-option global powerline_position_bg    black
+}
+

--- a/rc/themes/solarized-light-termcolors.kak
+++ b/rc/themes/solarized-light-termcolors.kak
@@ -1,0 +1,24 @@
+# Powerline colorscheme for solarized-light-termcolors Kakoune theme
+
+set-option -add global powerline_themes "solarized-light-termcolors"
+
+define-command -hidden powerline-theme-solarized-light-termcolors %{
+    set-option global powerline_base_bg        white
+    set-option global powerline_git_fg         cyan
+    set-option global powerline_git_bg         white
+    set-option global powerline_bufname_fg     black
+    set-option global powerline_bufname_bg     bright-cyan
+    set-option global powerline_line_column_fg black
+    set-option global powerline_line_column_bg bright-yellow
+    set-option global powerline_mode_info_fg   bright-cyan
+    set-option global powerline_mode_info_bg   white
+    set-option global powerline_filetype_fg    black
+    set-option global powerline_filetype_bg    bright-cyan
+    set-option global powerline_client_fg      black
+    set-option global powerline_client_bg      bright-blue
+    set-option global powerline_session_fg     black
+    set-option global powerline_session_bg     bright-yellow
+    set-option global powerline_position_fg    bright-red
+    set-option global powerline_position_bg    black
+}
+


### PR DESCRIPTION
**Breaking change**: no
**Description**:
Kakoune has support for the `solarized-{dark,light}-termcolors` color schemes: those are identical to the rgb variants, but uses 4-bit color names. Note that this only works properly if you've configured your terminal to use the proper termcolor values.
