### PR TITLE
Fix position section

### DIFF
--- a/rc/modules/position.kak
+++ b/rc/modules/position.kak
@@ -49,7 +49,7 @@ define-command -hidden powerline-update-position %{ evaluate-commands %sh{ (
             position="⠉"
         fi
     fi
-    printf "%s\n" "evaluate-commands -buffer $kak_bufname %{ set-option buffer powerline_position $position }" | kak -p $kak_session
+    printf "%s\n" "evaluate-commands -client $kak_client %{ set-option window powerline_position $position }" | kak -p $kak_session
 ) >/dev/null 2>&1 </dev/null & }}
 
 define-command -hidden powerline-position %{ evaluate-commands %sh{


### PR DESCRIPTION
Separate position section update for same buffer opened in multiple
windows in same session

**Breaking change**: No
<!-- Please provide meaningful description about your contribution -->
**Description**:
Previously if same buffer was open in multiple windows in the same session, on every cursor move position was updated for all windows with this buffer opened. This commit fixes that, hopefully without breaking any other cases I may not be aware of.

<!-- note that code will be reviewed and changes much likely will be requested -->
