### PR TITLE
Fix documentation (and comments) for colour usage: fg/bg swap on modules `client`, `session`

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ other modules, if possible. These colors are used by default modules:
 | Module Name | Foreground |        Background |
 |:------------|-----------:|------------------:|
 | bufname     |    color00 |           color03 |
-| client      |    color12 |           color13 |
+| client      |    color13 |           color12 |
 | filetype    |    color10 |           color11 |
 | git         |    color02 |           color04 |
 | line-column |    color06 |           color09 |
 | mode-info   |    color07 | base_bg (color08) |
 | position    |    color05 |           color01 |
-| session     |    color14 |           color15 |
+| session     |    color15 |           color14 |
 | lsp         |    color06 |           color09 |
 
 Colors from `color16` to `color31` are declared by the main script, but not used

--- a/rc/powerline.kak
+++ b/rc/powerline.kak
@@ -58,13 +58,13 @@ str powerlinefmt
 # | Name        | foreground | background   |
 # |-------------+------------+--------------|
 # | bufname     | color00    | color03      |
-# | client      | color12    | color13      |
+# | client      | color13    | color12      |
 # | filetype    | color10    | color11      |
 # | git         | color02    | color04      |
 # | line-column | color06    | color09      |
 # | mode-info   | color07    | base_bg (08) |
 # | position    | color05    | color01      |
-# | session     | color14    | color15      |
+# | session     | color15    | color14      |
 # | lsp         | color06    | color09      |
 
 declare-option -hidden str powerline_color00 black  # fg: bufname
@@ -81,8 +81,8 @@ declare-option -hidden str powerline_color10 yellow # fg: filetype
 declare-option -hidden str powerline_color11 black  # bg: filetype
 declare-option -hidden str powerline_color12 blue   # bg: client
 declare-option -hidden str powerline_color13 black  # fg: client
-declare-option -hidden str powerline_color14 cyan   # fg: session
-declare-option -hidden str powerline_color15 black  # bg: session
+declare-option -hidden str powerline_color14 cyan   # bg: session
+declare-option -hidden str powerline_color15 black  # fg: session
 declare-option -hidden str powerline_color16 black  # unused
 declare-option -hidden str powerline_color17 yellow # unused
 declare-option -hidden str powerline_color18 green  # unused

--- a/rc/themes/base16-gruvbox.kak
+++ b/rc/themes/base16-gruvbox.kak
@@ -21,8 +21,8 @@ define-command -hidden powerline-theme-base16-gruvbox %{
     declare-option -hidden str powerline_color11 "rgb:504945" # bg: filetype
     declare-option -hidden str powerline_color12 "rgb:665c54" # bg: client
     declare-option -hidden str powerline_color13 "rgb:ebdbb2" # fg: client
-    declare-option -hidden str powerline_color14 "rgb:7c6f64" # fg: session
-    declare-option -hidden str powerline_color15 "rgb:fbf1c7" # bg: session
+    declare-option -hidden str powerline_color14 "rgb:7c6f64" # bg: session
+    declare-option -hidden str powerline_color15 "rgb:fbf1c7" # fg: session
     declare-option -hidden str powerline_color16 "rgb:282828" # unused
     declare-option -hidden str powerline_color17 "rgb:a89984" # unused
     declare-option -hidden str powerline_color18 "rgb:bdae93" # unused

--- a/rc/themes/base16.kak
+++ b/rc/themes/base16.kak
@@ -33,8 +33,8 @@ define-command -hidden powerline-theme-base16 %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${grey_dark}       # bg: filetype
         declare-option -hidden str powerline_color12 ${purple_dark}     # bg: client
         declare-option -hidden str powerline_color13 ${black_lighter}   # fg: client
-        declare-option -hidden str powerline_color14 ${black_lighter}   # fg: session
-        declare-option -hidden str powerline_color15 ${magenta_dark}    # bg: session
+        declare-option -hidden str powerline_color14 ${black_lighter}   # bg: session
+        declare-option -hidden str powerline_color15 ${magenta_dark}    # fg: session
         declare-option -hidden str powerline_color16 ${black_light}     # unused
         declare-option -hidden str powerline_color17 ${cyan_light}      # unused
         declare-option -hidden str powerline_color18 ${cyan_light}      # unused

--- a/rc/themes/default.kak
+++ b/rc/themes/default.kak
@@ -20,8 +20,8 @@ define-command -hidden powerline-theme-default %{
     declare-option -hidden str powerline_color11 black  # bg: filetype
     declare-option -hidden str powerline_color12 blue   # bg: client
     declare-option -hidden str powerline_color13 black  # fg: client
-    declare-option -hidden str powerline_color14 cyan   # fg: session
-    declare-option -hidden str powerline_color15 black  # bg: session
+    declare-option -hidden str powerline_color14 cyan   # bg: session
+    declare-option -hidden str powerline_color15 black  # fg: session
     declare-option -hidden str powerline_color16 black  # unused
     declare-option -hidden str powerline_color17 yellow # unused
     declare-option -hidden str powerline_color18 green  # unused

--- a/rc/themes/desertex.kak
+++ b/rc/themes/desertex.kak
@@ -20,8 +20,8 @@ define-command -hidden powerline-theme-desertex %{
     declare-option -hidden str powerline_color11 blue       # bg: filetype
     declare-option -hidden str powerline_color12 rgb:fa8072 # bg: client
     declare-option -hidden str powerline_color13 black      # fg: client
-    declare-option -hidden str powerline_color14 black      # fg: session
-    declare-option -hidden str powerline_color15 magenta    # bg: session
+    declare-option -hidden str powerline_color14 black      # bg: session
+    declare-option -hidden str powerline_color15 magenta    # fg: session
     declare-option -hidden str powerline_color16 black      # unused
     declare-option -hidden str powerline_color17 yellow     # unused
     declare-option -hidden str powerline_color18 blue       # unused

--- a/rc/themes/github.kak
+++ b/rc/themes/github.kak
@@ -20,8 +20,8 @@ define-command -hidden powerline-theme-github %{
     declare-option -hidden str powerline_color11 rgb:A71D5D # bg: filetype
     declare-option -hidden str powerline_color12 rgb:4078C0 # bg: client
     declare-option -hidden str powerline_color13 rgb:F8F8FF # fg: client
-    declare-option -hidden str powerline_color14 rgb:F8F8FF # fg: session
-    declare-option -hidden str powerline_color15 rgb:795DA3 # bg: session
+    declare-option -hidden str powerline_color14 rgb:F8F8FF # bg: session
+    declare-option -hidden str powerline_color15 rgb:795DA3 # fg: session
     declare-option -hidden str powerline_color16 rgb:F8F8FF # unused
     declare-option -hidden str powerline_color17 rgb:4078C0 # unused
     declare-option -hidden str powerline_color18 rgb:4078C0 # unused

--- a/rc/themes/greyscale.kak
+++ b/rc/themes/greyscale.kak
@@ -44,8 +44,8 @@ define-command -hidden powerline-theme-greyscale %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${bg1}    # bg: filetype
         declare-option -hidden str powerline_color12 ${bg2}    # bg: client
         declare-option -hidden str powerline_color13 ${fg2}    # fg: client
-        declare-option -hidden str powerline_color14 ${fg}     # fg: session
-        declare-option -hidden str powerline_color15 ${bg3}    # bg: session
+        declare-option -hidden str powerline_color14 ${fg}     # bg: session
+        declare-option -hidden str powerline_color15 ${bg3}    # fg: session
         declare-option -hidden str powerline_color16 ${bg}     # unused
         declare-option -hidden str powerline_color17 ${bg4}    # unused
         declare-option -hidden str powerline_color18 ${fg}     # unused

--- a/rc/themes/gruvbox.kak
+++ b/rc/themes/gruvbox.kak
@@ -42,8 +42,8 @@ define-command -hidden powerline-theme-gruvbox %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${bg1}    # bg: filetype
         declare-option -hidden str powerline_color12 ${bg2}    # bg: client
         declare-option -hidden str powerline_color13 ${fg2}    # fg: client
-        declare-option -hidden str powerline_color14 ${fg}     # fg: session
-        declare-option -hidden str powerline_color15 ${bg3}    # bg: session
+        declare-option -hidden str powerline_color14 ${fg}     # bg: session
+        declare-option -hidden str powerline_color15 ${bg3}    # fg: session
         declare-option -hidden str powerline_color16 ${bg}     # unused
         declare-option -hidden str powerline_color17 ${bg4}    # unused
         declare-option -hidden str powerline_color18 ${yellow} # unused

--- a/rc/themes/kaleidoscope-dark.kak
+++ b/rc/themes/kaleidoscope-dark.kak
@@ -107,8 +107,8 @@ define-command -hidden powerline-theme-kaleidoscope-dark %{ evaluate-commands %s
         declare-option -hidden str powerline_color11 ${bg3}    # bg: filetype
         declare-option -hidden str powerline_color12 ${bg2}    # bg: client
         declare-option -hidden str powerline_color13 ${fg2}    # fg: client
-        declare-option -hidden str powerline_color14 ${fg}     # fg: session
-        declare-option -hidden str powerline_color15 ${bg3}    # bg: session
+        declare-option -hidden str powerline_color14 ${fg}     # bg: session
+        declare-option -hidden str powerline_color15 ${bg3}    # fg: session
         declare-option -hidden str powerline_color16 ${bg}     # unused
         declare-option -hidden str powerline_color17 ${bg4}    # unused
         declare-option -hidden str powerline_color18 ${yellow} # unused

--- a/rc/themes/lucius.kak
+++ b/rc/themes/lucius.kak
@@ -63,8 +63,8 @@ define-command -hidden powerline-theme-lucius %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${bg1}    # bg: filetype
         declare-option -hidden str powerline_color12 ${bg2}    # bg: client
         declare-option -hidden str powerline_color13 ${fg2}    # fg: client
-        declare-option -hidden str powerline_color14 ${fg}     # fg: session
-        declare-option -hidden str powerline_color15 ${bg}     # bg: session
+        declare-option -hidden str powerline_color14 ${fg}     # bg: session
+        declare-option -hidden str powerline_color15 ${bg}     # fg: session
         declare-option -hidden str powerline_color16 ${bg}     # unused
         declare-option -hidden str powerline_color17 ${bg4}    # unused
         declare-option -hidden str powerline_color18 ${yellow} # unused

--- a/rc/themes/palenight.kak
+++ b/rc/themes/palenight.kak
@@ -62,8 +62,8 @@ define-command -hidden powerline-theme-palenight %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${bg1}    # bg: filetype
         declare-option -hidden str powerline_color12 ${bg2}    # bg: client
         declare-option -hidden str powerline_color13 ${fg2}    # fg: client
-        declare-option -hidden str powerline_color14 ${fg3}    # fg: session
-        declare-option -hidden str powerline_color15 ${bg3}    # bg: session
+        declare-option -hidden str powerline_color14 ${fg3}    # bg: session
+        declare-option -hidden str powerline_color15 ${bg3}    # fg: session
         declare-option -hidden str powerline_color16 ${bg}     # unused
         declare-option -hidden str powerline_color17 ${bg4}    # unused
         declare-option -hidden str powerline_color18 ${yellow} # unused

--- a/rc/themes/red-phoenix.kak
+++ b/rc/themes/red-phoenix.kak
@@ -40,8 +40,8 @@ define-command -hidden powerline-theme-red-phoenix %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${light_orange1} # bg: filetype
         declare-option -hidden str powerline_color12 ${orange2}       # bg: client
         declare-option -hidden str powerline_color13 ${default}       # fg: client
-        declare-option -hidden str powerline_color14 ${default}       # fg: session
-        declare-option -hidden str powerline_color15 ${orange3}       # bg: session
+        declare-option -hidden str powerline_color14 ${default}       # bg: session
+        declare-option -hidden str powerline_color15 ${orange3}       # fg: session
         declare-option -hidden str powerline_color16 white            # unused
         declare-option -hidden str powerline_color17 ${orange1}       # unused
         declare-option -hidden str powerline_color18 white            # unused

--- a/rc/themes/reeder.kak
+++ b/rc/themes/reeder.kak
@@ -35,8 +35,8 @@ define-command -hidden powerline-theme-reeder %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${grey_dark}     # bg: filetype
         declare-option -hidden str powerline_color12 ${black_light}   # bg: client
         declare-option -hidden str powerline_color13 ${grey_dark}     # fg: client
-        declare-option -hidden str powerline_color14 ${grey_dark}     # fg: session
-        declare-option -hidden str powerline_color15 ${black}         # bg: session
+        declare-option -hidden str powerline_color14 ${grey_dark}     # bg: session
+        declare-option -hidden str powerline_color15 ${black}         # fg: session
         declare-option -hidden str powerline_color16 ${black_light}   # unused
         declare-option -hidden str powerline_color17 ${brown_lighter} # unused
         declare-option -hidden str powerline_color18 ${black_light}   # unused

--- a/rc/themes/solarized-dark-termcolors.kak
+++ b/rc/themes/solarized-dark-termcolors.kak
@@ -20,8 +20,8 @@ define-command -hidden powerline-theme-solarized-dark-termcolors %{
     declare-option -hidden str powerline_color11 bright-cyan   # bg: filetype
     declare-option -hidden str powerline_color12 bright-blue   # bg: client
     declare-option -hidden str powerline_color13 black         # fg: client
-    declare-option -hidden str powerline_color14 black         # fg: session
-    declare-option -hidden str powerline_color15 bright-yellow # bg: session
+    declare-option -hidden str powerline_color14 black         # bg: session
+    declare-option -hidden str powerline_color15 bright-yellow # fg: session
     declare-option -hidden str powerline_color16 black         # unused
     declare-option -hidden str powerline_color17 bright-red    # unused
     declare-option -hidden str powerline_color18 cyan          # unused

--- a/rc/themes/solarized-dark.kak
+++ b/rc/themes/solarized-dark.kak
@@ -38,8 +38,8 @@ define-command -hidden powerline-theme-solarized-dark %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${base1}  # bg: filetype
         declare-option -hidden str powerline_color12 ${base0}  # bg: client
         declare-option -hidden str powerline_color13 ${base02} # fg: client
-        declare-option -hidden str powerline_color14 ${base02} # fg: session
-        declare-option -hidden str powerline_color15 ${base00} # bg: session
+        declare-option -hidden str powerline_color14 ${base02} # bg: session
+        declare-option -hidden str powerline_color15 ${base00} # fg: session
         declare-option -hidden str powerline_color16 ${base02} # unused
         declare-option -hidden str powerline_color17 ${orange} # unused
         declare-option -hidden str powerline_color18 ${cyan}   # unused

--- a/rc/themes/solarized-light-termcolors.kak
+++ b/rc/themes/solarized-light-termcolors.kak
@@ -20,8 +20,8 @@ define-command -hidden powerline-theme-solarized-light-termcolors %{
     declare-option -hidden str powerline_color11 bright-cyan   # bg: filetype
     declare-option -hidden str powerline_color12 bright-blue   # bg: client
     declare-option -hidden str powerline_color13 black         # fg: client
-    declare-option -hidden str powerline_color14 black         # fg: session
-    declare-option -hidden str powerline_color15 bright-yellow # bg: session
+    declare-option -hidden str powerline_color14 black         # bg: session
+    declare-option -hidden str powerline_color15 bright-yellow # fg: session
     declare-option -hidden str powerline_color16 black         # unused
     declare-option -hidden str powerline_color17 bright-red    # unused
     declare-option -hidden str powerline_color18 cyan          # unused

--- a/rc/themes/solarized-light.kak
+++ b/rc/themes/solarized-light.kak
@@ -38,8 +38,8 @@ define-command -hidden powerline-theme-solarized-light %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${base1}  # bg: filetype
         declare-option -hidden str powerline_color12 ${base0}  # bg: client
         declare-option -hidden str powerline_color13 ${base02} # fg: client
-        declare-option -hidden str powerline_color14 ${base02} # fg: session
-        declare-option -hidden str powerline_color15 ${base00} # bg: session
+        declare-option -hidden str powerline_color14 ${base02} # bg: session
+        declare-option -hidden str powerline_color15 ${base00} # fg: session
         declare-option -hidden str powerline_color16 ${base02} # unused
         declare-option -hidden str powerline_color17 ${orange} # unused
         declare-option -hidden str powerline_color18 ${cyan}   # unused

--- a/rc/themes/tomorrow-night.kak
+++ b/rc/themes/tomorrow-night.kak
@@ -39,8 +39,8 @@ define-command -hidden powerline-theme-tomorrow-night %{ evaluate-commands %sh{
         declare-option -hidden str powerline_color11 ${line}   # bg: filetype
         declare-option -hidden str powerline_color12 ${window} # bg: client
         declare-option -hidden str powerline_color13 ${aqua}   # fg: client
-        declare-option -hidden str powerline_color14 ${aqua}   # fg: session
-        declare-option -hidden str powerline_color15 ${line}   # bg: session
+        declare-option -hidden str powerline_color14 ${aqua}   # bg: session
+        declare-option -hidden str powerline_color15 ${line}   # fg: session
         declare-option -hidden str powerline_color16 white     # unused
         declare-option -hidden str powerline_color17 ${window} # unused
         declare-option -hidden str powerline_color18 ${aqua}   # unused

--- a/rc/themes/zenburn.kak
+++ b/rc/themes/zenburn.kak
@@ -20,8 +20,8 @@ define-command -hidden powerline-theme-zenburn %{
     declare-option -hidden str powerline_color11 rgb:4a4a4a # bg: filetype
     declare-option -hidden str powerline_color12 rgb:2a2a2a # bg: client
     declare-option -hidden str powerline_color13 rgb:cc9393 # fg: client
-    declare-option -hidden str powerline_color14 rgb:7f9f7f # fg: session
-    declare-option -hidden str powerline_color15 rgb:4a4a4a # bg: session
+    declare-option -hidden str powerline_color14 rgb:7f9f7f # bg: session
+    declare-option -hidden str powerline_color15 rgb:4a4a4a # fg: session
     declare-option -hidden str powerline_color16 rgb:cc9393 # unused
     declare-option -hidden str powerline_color17 rgb:2a2a2a # unused
     declare-option -hidden str powerline_color18 rgb:7f9f7f # unused


### PR DESCRIPTION
**Breaking change**: no

**Description**:

Colour usage is documented at various places in the repository, including the README.md file, the main powerline.kak script, and the colour themes themselves. Looking at those various files, it appears that the description for a few colours is incorrect: the foreground and background colours are swapped for the client module in several cases, and for the session module in all cases.

We could address either by updating the documentation, or by changing the colours in use to reflect the current documentation. The latter option would likely introduce colour changes for the users of the existing themes, so instead we simply update the documentation and do not change how the colours are used.