### PR TITLE
Add a base to separators' colours, to fix transparency

### DIFF
--- a/rc/modules/bufname.kak
+++ b/rc/modules/bufname.kak
@@ -29,7 +29,7 @@ define-command -hidden powerline-bufname %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_bufname" = "true" ]; then
         fg=$kak_opt_powerline_color00
         bg=$kak_opt_powerline_color03
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} %opt{powerline_bufname}{{context_info}}%opt{powerline_readonly} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/modules/client.kak
+++ b/rc/modules/client.kak
@@ -22,7 +22,7 @@ define-command -hidden powerline-client %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_client" = "true" ]; then
         bg=$kak_opt_powerline_color12
         fg=$kak_opt_powerline_color13
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} %val{client} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/modules/codepoint.kak
+++ b/rc/modules/codepoint.kak
@@ -20,7 +20,7 @@ define-command -hidden powerline-codepoint %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_mode_info" = "true" ]; then
         bg=$kak_opt_powerline_color11
         fg=$kak_opt_powerline_color10
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} U+%opt{powerline_codepoint} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/modules/filetype.kak
+++ b/rc/modules/filetype.kak
@@ -23,7 +23,7 @@ define-command -hidden powerline-filetype %{ evaluate-commands %sh{
         fg=$kak_opt_powerline_color10
         bg=$kak_opt_powerline_color11
         if [ ! -z "$kak_opt_filetype" ]; then
-            [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+            [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
             printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} %opt{filetype} }"
             printf "%s\n" "set-option global powerline_next_bg $bg"
         fi

--- a/rc/modules/git.kak
+++ b/rc/modules/git.kak
@@ -37,7 +37,7 @@ define-command -hidden powerline-git %{ evaluate-commands %sh{
         bg=$kak_opt_powerline_color04
         printf "%s\n" "powerline-update-branch"
         if [ -n "$kak_opt_powerline_branch" ]; then
-            [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+            [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
             printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} %opt{powerline_branch} }"
             printf "%s\n" "set-option global powerline_next_bg $bg"
             printf "%s\n" "powerline-update-branch"

--- a/rc/modules/line_column.kak
+++ b/rc/modules/line_column.kak
@@ -22,7 +22,7 @@ define-command -hidden powerline-line-column %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_line_column" = "true" ]; then
         fg=$kak_opt_powerline_color06
         bg=$kak_opt_powerline_color09
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} %val{cursor_line}{$fg,$bg}:{$fg,$bg}%val{cursor_char_column} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/modules/lsp.kak
+++ b/rc/modules/lsp.kak
@@ -23,7 +23,7 @@ define-command -hidden powerline-lsp %{
             if [ "$kak_opt_powerline_module_lsp" = "true" ]; then
                 fg=$kak_opt_powerline_color06
                 bg=$kak_opt_powerline_color09
-                [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+                [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
                 printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} E:%opt{lsp_diagnostic_error_count} W:%opt{lsp_diagnostic_warning_count} }"
                 printf "%s\n" "set-option global powerline_next_bg $bg"
             fi

--- a/rc/modules/mode_info.kak
+++ b/rc/modules/mode_info.kak
@@ -22,7 +22,7 @@ define-command -hidden powerline-mode-info %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_mode_info" = "true" ]; then
         bg=$kak_opt_powerline_base_bg
         fg=$kak_opt_powerline_color07
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} {{mode_info}} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/modules/position.kak
+++ b/rc/modules/position.kak
@@ -60,7 +60,7 @@ define-command -hidden powerline-position %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_position" = "true" ]; then
         bg=$kak_opt_powerline_color01
         fg=$kak_opt_powerline_color05
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} ≣ %opt{powerline_position} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/modules/session.kak
+++ b/rc/modules/session.kak
@@ -22,7 +22,7 @@ define-command -hidden powerline-session %{ evaluate-commands %sh{
     if [ "$kak_opt_powerline_module_session" = "true" ]; then
         bg=$kak_opt_powerline_color14
         fg=$kak_opt_powerline_color15
-        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}}$normal"
+        [ "$next_bg" = "$bg" ] && separator="{$fg,$bg}$thin" || separator="{$bg,${next_bg:-$default}@powerline_base}$normal"
         printf "%s\n" "set-option -add global powerlinefmt %{$separator{$fg,$bg} %val{session} }"
         printf "%s\n" "set-option global powerline_next_bg $bg"
     fi

--- a/rc/powerline.kak
+++ b/rc/powerline.kak
@@ -152,6 +152,8 @@ powerline-rebuild-buffer %{
         printf "%s\n" "set-option global powerlinefmt ''"
         printf "%s\n" "set-option global powerline_next_bg %opt{powerline_base_bg}"
 
+        printf "%s\n" "set-face global powerline_base $kak_opt_powerline_base_bg,$kak_opt_powerline_base_bg"
+
         for module in ${kak_opt_powerline_format}; do
             [ ! "${kak_opt_powerline_ignore_warnings}" = "true" ] && warning="catch %{ echo -debug %{powerline.kak: Warning, trying to load non-existing module '${module}'} }"
             module=$(printf "%s\n" ${module} | sed "s:[^a-zA-Z-]:-:g")


### PR DESCRIPTION
### Breaking change

no

The new face has no attributes or underline colour set, therefore it should not change the appearance of any opaque colour applied on top of it. For transparent colours, it should harmonise the colours of the separators with the colours of the rest of the segments.

### Description

Define a new `powerline_base` face with the default background colour as both background and foreground, and use it as a base when passing the faces for the separators between the different segments of the Powerline.

Kakoune supports transparent colours in faces. If:

1) the background colour used for this base (through `%opt{powerline_base_bg}`, usually alined on `%opt{powerline_color08}`) is an RGB colour defined as `rgb:RRGGBB` or `rgba::RRGGBBAA`
2) colours applied on top of it, for example `powerline_color03` for the bufname background, have an alpha value set

... Then transparency can be applied even to the background colour for the segment, resulting in the blending of `powerline_color03` with the buffer background colour.

One use case, for example, is to build a colour theme for the modeline with different shades from a single colour, playing on the values of the alpha channel. Such a scheme presents two advantages: first, we do not have to pick individual colours for each segment background. Finding a single hexadecimal code is enough (and we can even reuse some colours from Kakoune's current colour scheme). Secondly, this theme is trivial to adapt when we switch to a different Kakoune colour scheme.

Let's consider the following example, relying on a colour scheme for Kakoune that defines a colour named `black` and uses it as a background colour for the buffer, and a `white` colour for its foreground. This is the case, for example, of several themes available [here](https://github.com/anhsirk0/kakoune-themes) (although `black` is commented by default so that users can keep their terminal's background colour). We can define the following Powerline theme:

    hook global ModuleLoaded powerline %{ require-module powerline_test }
    provide-module powerline_test %§
    set-option -add global powerline_themes "test"
    define-command -hidden powerline-theme-test %{
        define-command -hidden powerline-theme-recolor %{

            # Extract the hexadecimal code for "black" and "white"
            declare-option -hidden str whitergb %sh{ color=$kak_opt_white; printf "%s" "${color#rgb:}" }
            declare-option -hidden str blackrgb %sh{ color=$kak_opt_black; printf "%s" "${color#rgb:}" }
            declare-option -hidden str powerline_color02 "rgba:%opt{blackrgb}ff" # fg: git
            declare-option -hidden str powerline_color04 "rgba:%opt{whitergb}ff" # bg: git
            declare-option -hidden str powerline_color00 "rgba:%opt{blackrgb}ff" # fg: bufname
            declare-option -hidden str powerline_color03 "rgba:%opt{whitergb}a0" # bg: bufname
            declare-option -hidden str powerline_color06 "rgba:%opt{whitergb}ff" # fg: line-column, lsp
            declare-option -hidden str powerline_color09 "rgba:%opt{whitergb}40" # bg: line-column, lsp
            declare-option -hidden str powerline_color07 "rgba:%opt{blackrgb}ff" # fg: mode-info
            declare-option -hidden str powerline_color08 "rgba:%opt{blackrgb}ff" # base background, bg: mode-info
            declare-option -hidden str powerline_color10 "rgba:%opt{blackrgb}ff" # fg: filetype
            declare-option -hidden str powerline_color11 "rgba:%opt{whitergb}aa" # bg: filetype
            declare-option -hidden str powerline_color13 "rgba:%opt{whitergb}ff" # fg: client
            declare-option -hidden str powerline_color12 "rgba:%opt{whitergb}40" # bg: client
            declare-option -hidden str powerline_color15 "rgba:%opt{blackrgb}ff" # fg: session
            declare-option -hidden str powerline_color14 "rgba:%opt{whitergb}a0" # bg: session
            declare-option -hidden str powerline_color05 "rgba:%opt{blackrgb}ff" # fg: position
            declare-option -hidden str powerline_color01 "rgba:%opt{whitergb}ff" # bg: position

            declare-option -hidden str powerline_next_bg %opt{powerline_color08}
            declare-option -hidden str powerline_base_bg %opt{powerline_color08}
        }
        powerline-theme-recolor
    }
    §

This way, we create a Powerline theme that is automatically adjusted to the colour scheme that Kakoune uses on startup. We can replace the call to "powerline-theme-recolor" with the following:

        hook global BufSetOption ^black=.* %{
            powerline-theme-recolor
            powerline-rebuild-buffer
        }

This time, we even recompute the colours when the main colour scheme changes (in practice, when the `black` option changes): switching from ayu-dark to pastel and then to monokai makes the Powerline theme adjust automatically!

Most of this is already possible with the existing code, provided the colour theme for Kakoune uses RGB colours for foreground and background. However, the base for the separators needs to be adjusted, because their foreground is in fact a background value (the one of the coming segment), thus necessiting base with the buffer background colour as foreground instead of `Default`.

### Screenshots

[Ayu-dark with `black` colour uncommented](https://github.com/anhsirk0/kakoune-themes/blob/master/colors/ayu-dark.kak#L4), **before the patch**. Note the inconsistent appearance of the separators (no foreground transparency, or rather, blending in of `white` with `white`, resulting in an opaque colour):
![ayu-broken](https://user-images.githubusercontent.com/8324081/153955775-7ace11c3-c648-4146-9c3a-84663a30985a.png)

Ayu-dark (same), with the Powerline **patch applied**:
![ayu](https://user-images.githubusercontent.com/8324081/153955834-070c931a-7ef1-4507-89a4-13e861814b04.png)

After typing `:colorscheme monokai` (also edited to set the `black` colour):
![monokai](https://user-images.githubusercontent.com/8324081/153955914-7cb65642-ac51-4af3-8975-6476b0c60551.png)

After typing `:colorscheme mygruvbox` (idem):
![mygruvbox](https://user-images.githubusercontent.com/8324081/153955963-66486636-1aa6-4d15-bbe2-fdcf2534fe26.png)

After typing `:colorscheme pastel` (idem):
![pastel](https://user-images.githubusercontent.com/8324081/153956028-9cf3ae7f-5e6e-4d55-9e9f-d9367914e615.png)
